### PR TITLE
Update CapTP version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import './src/lockdown.js';
 import { makeCapTP, E } from '@agoric/captp';
 import { Duplex } from 'stream';
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-const capTp = require('@agoric/captp');
-const { makeCapTP, E } = capTp;
-const { Duplex } = require('stream');
+import { makeCapTP, E } from '@agoric/captp';
+import { Duplex } from 'stream';
 
-function makeCapTpFromStream (streamId, bootstrap) {
+export default function makeCapTpFromStream (streamId, bootstrap) {
   let dispatch, getBootstrap, abort;
 
   const stream = new Duplex();
@@ -22,7 +21,7 @@ function makeCapTpFromStream (streamId, bootstrap) {
     } catch (err) {
       return cb(err);
     }
-    cb();    
+    cb();
   };
 
   stream._writev = (chunks, cb) => {
@@ -43,7 +42,5 @@ function makeCapTpFromStream (streamId, bootstrap) {
 
   return { getBootstrap, abort, E, captpStream: stream }
 };
-
-module.exports = makeCapTpFromStream;
 
 function noop () {}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "node test"
   },
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/danfinlay/captp-stream.git"
@@ -22,14 +23,14 @@
   },
   "homepage": "https://github.com/danfinlay/captp-stream#readme",
   "dependencies": {
-    "@agoric/captp": "^1.2.3"
+    "@agoric/captp": "^1.10.6"
   },
   "devDependencies": {
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
     "minipass": "^3.1.1",
     "obj-multiplex": "^1.0.0",
     "pumpify": "^2.0.1",
+    "ses": "^0.15.0",
     "tape": "^4.13.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captp-stream",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A simple module for constructing a capTP interface over a stream.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@agoric/captp": "^1.10.6"
   },
   "devDependencies": {
-    "@agoric/eventual-send": "^0.8.0",
+    "@agoric/eventual-send": "^0.13.30",
     "minipass": "^3.1.1",
     "obj-multiplex": "^1.0.0",
     "pumpify": "^2.0.1",

--- a/src/duplex-socket.js
+++ b/src/duplex-socket.js
@@ -1,7 +1,7 @@
 // From: https://stackoverflow.com/a/55136548/272576
 // Modified to our eslint and to support object-mode.
-const Duplex = require('stream').Duplex
-const assert = require('assert')
+import { Duplex } from 'stream';
+import assert from 'assert';
 
 // Define some unique property names.
 // The actual value doesn't matter,
@@ -67,4 +67,4 @@ function makeDuplexPair () {
   return { clientSide, serverSide }
 }
 
-module.exports = makeDuplexPair
+export default makeDuplexPair;

--- a/src/lockdown.js
+++ b/src/lockdown.js
@@ -1,2 +1,3 @@
 import 'ses';
+import '@agoric/eventual-send/shim.js';
 lockdown();

--- a/src/lockdown.js
+++ b/src/lockdown.js
@@ -1,0 +1,2 @@
+import 'ses';
+lockdown();

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,10 @@
-const test = require('tape');
-const makeDuplexPair = require('../src/duplex-socket');
-const makeCapTpFromStream = require('../');
-const harden = require('@agoric/harden');
-const pumpify = require('pumpify');
+import test from 'tape';
+import 'ses';
+import assert from 'assert';
+lockdown();
+import makeDuplexPair from '../src/duplex-socket.js';
+import makeCapTpFromStream from '../index.js';
+import pumpify from 'pumpify';
 
 test('basic connection', async (t) => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,7 @@
 import test from 'tape';
-import 'ses';
 import assert from 'assert';
-lockdown();
-import makeDuplexPair from '../src/duplex-socket.js';
 import makeCapTpFromStream from '../index.js';
+import makeDuplexPair from '../src/duplex-socket.js';
 import pumpify from 'pumpify';
 
 test('basic connection', async (t) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,28 @@
 # yarn lockfile v1
 
 
-"@agoric/captp@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@agoric/captp/-/captp-1.2.3.tgz#0f45c17860954cb712ed22ccb239b208d0f46df0"
-  integrity sha512-tomX0jaHI/Ue+OOknunprPy/0B3lnKP2O+dondEr2XflQZb4qxkZ5aov8Q+F5nJr2OySQHmN1q+CpuMrWf8t8Q==
+"@agoric/assert@^0.3.14":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.14.tgz#5ba32391253a5412969e9827815203cfed6759a7"
+  integrity sha512-xmTJImBq4AgNQ8PeAjmYXq6Ori3enuLsl2ogcveGBadJNzsyIuib2XZrG4zJxq7qArtvS8k/2qVoLDf8Q1UiUg==
   dependencies:
-    "@agoric/eventual-send" "^0.8.0"
-    "@agoric/harden" "^0.0.4"
-    "@agoric/marshal" "^0.1.5"
-    "@agoric/nat" "^2.0.1"
-    "@agoric/produce-promise" "^0.0.5"
-    esm "^3.2.5"
-    rollup "^1.24.0"
-    rollup-plugin-commonjs "^10.1.0"
-    rollup-plugin-node-resolve "^5.2.0"
+    ses "^0.14.3"
+
+"@agoric/captp@^1.10.6":
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/@agoric/captp/-/captp-1.10.6.tgz#7d4030f613230f666c2ef7b40c0684ac21a11d3a"
+  integrity sha512-+H0nAC1/6v4HoEm0clSOQGvTOPFBcXrP1LtWN/D6fdO19wPURHpE1SvY0UEH0wAdRjk3NBOEasHVypbRfE8O6w==
+  dependencies:
+    "@agoric/assert" "^0.3.14"
+    "@agoric/eventual-send" "^0.13.30"
+    "@agoric/marshal" "^0.4.28"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/promise-kit" "^0.2.28"
+
+"@agoric/eventual-send@^0.13.30":
+  version "0.13.30"
+  resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.13.30.tgz#5addee2d18c165f477b89b7b4f44e48a4da29d17"
+  integrity sha512-jwn4o161Jm/TWcPg0pE3UtJ2y1/0FEFmDVivDJIqI+K5freXXwr0OT2TOIctQGdsvNASPtRZLrdVUk9diYLbYQ==
 
 "@agoric/eventual-send@^0.8.0":
   version "0.8.0"
@@ -24,79 +32,39 @@
   dependencies:
     "@agoric/harden" "^0.0.4"
 
-"@agoric/harden@0.0.4", "@agoric/harden@^0.0.4":
+"@agoric/harden@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@agoric/harden/-/harden-0.0.4.tgz#b0d0b2fdfc1a8c7e60454374824442f5b37ea8bd"
   integrity sha512-WvTw2otvchy3mScAvqQcX0l6049xp6cF17/Pw0PNNqUTJtOo/84tE9OyBSjEp8wn/XBNArPaJuRjMhQpIQ775Q==
   dependencies:
     "@agoric/make-hardener" "0.0.4"
 
-"@agoric/harden@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@agoric/harden/-/harden-0.0.7.tgz#1e6ff3b76e0dd73264cd0df58bb3090a84b3733a"
-  integrity sha512-vVdJhwg0weup94ez9TLjPTTEx6TVzjWmrt+Mbq0VMPBcRdEg1RDsBcpgNoT+4h8ooZNvaTbCWwA77MyFAzDjIw==
-  dependencies:
-    "@agoric/make-hardener" "0.0.8"
-
 "@agoric/make-hardener@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.4.tgz#9b5d6692bc2fbbac2fff0a6682959ac5e69c582d"
   integrity sha512-0k/wGkIVQO3IY7p/H/5OS3BIXsRK9Qb7nHnqyvj6hzvSyumwgPp8e4rz5QaVWSen43TGJl+zQn4mW9ZZShT1aw==
 
-"@agoric/make-hardener@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.8.tgz#7f9e9d6874600b2e1b0543ce9456fbf62463be2d"
-  integrity sha512-bd83IYEMQbzpprwyA10RjHIGWmWeUMdsd5EzaHwke+zLH0HyqP6UKxFLv5mqkmrMeQyOMhNgKN1hCagjRyjlxQ==
-
-"@agoric/marshal@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.1.5.tgz#b0bdf9ebce8ef15cd7d7661bbff20306e0c30f93"
-  integrity sha512-9yGg3P5PHnQnXECz4Fc2Fpq/9De+UKAWk/sXDts7+J8UHq1cH2cmZ7+hHZ0Xfi4cR8b0fWpSlkMYNzrLXGDNug==
+"@agoric/marshal@^0.4.28":
+  version "0.4.28"
+  resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.4.28.tgz#cbbf9ebb41dcb382407af7a44d3f6eebc2d46726"
+  integrity sha512-Fc9qq4PtJipdmUMK1R/3R2cg+AO4rGvMvdbD0g9rNu5QP493ymQV2U3ytdpt8TNSbxqzfI+F7CnQEBq8fcSO3Q==
   dependencies:
-    "@agoric/eventual-send" "^0.8.0"
-    "@agoric/harden" "0.0.4"
-    "@agoric/nat" "^2.0.1"
-    "@agoric/produce-promise" "^0.0.5"
+    "@agoric/assert" "^0.3.14"
+    "@agoric/eventual-send" "^0.13.30"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/promise-kit" "^0.2.28"
 
-"@agoric/nat@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-2.0.1.tgz#28aba18367deba354bdd424bdf6daa48f5e7d37f"
-  integrity sha512-puvWkoaJovQib/YaSRSGJ8Kn9rogi/yyaVa3d5znSZb5WiYfUiEKW35BfexHhAdi0VfPz2anFHoRBoBSUIijNA==
+"@agoric/nat@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.1.0.tgz#102794e033ffc183a20b0f86031a2e76d204b9f6"
+  integrity sha512-2oMoh3DMn0Fx8HChPPiH8irBNdT/33ttxAZJohhd3nU3gyBRQ1u+eEoOQWfSkrE6M02iMkQM7GE9MzGmjQ6bHg==
 
-"@agoric/produce-promise@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@agoric/produce-promise/-/produce-promise-0.0.5.tgz#72cc10a492a47cf2ef634cea5f9a6c9de028ea00"
-  integrity sha512-0EvCGZpDDAA0c2OwDxZBkpHdUrv0svXfNsOzEYrKfUgyZlTcsrZMYybevv///iepUICKF86Y7cRI2/4WiIFqKQ==
+"@agoric/promise-kit@^0.2.28":
+  version "0.2.28"
+  resolved "https://registry.yarnpkg.com/@agoric/promise-kit/-/promise-kit-0.2.28.tgz#6b054460ddcc981c75626d763e1d2d6c8ad2ce4b"
+  integrity sha512-nHlGbOCF0tLfDhCszEqWdS7lpTlSHCDsM+enYAN50rSAQ6d+eSvj0d+dnXm4Lwm/O2OWDWjAe54McR8Qa4cyYA==
   dependencies:
-    "@agoric/eventual-send" "^0.8.0"
-    "@agoric/harden" "^0.0.4"
-
-"@types/estree@*":
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.44.tgz#980cc5a29a3ef3bea6ff1f7d021047d7ea575e21"
-  integrity sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==
-
-"@types/estree@0.0.39":
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-
-"@types/node@*":
-  version "13.13.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.0.tgz#30d2d09f623fe32cde9cb582c7a6eda2788ce4a8"
-  integrity sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A==
-
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
-  dependencies:
-    "@types/node" "*"
-
-acorn@^7.1.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
-  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+    "@agoric/eventual-send" "^0.13.30"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -110,11 +78,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-builtin-modules@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
-  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -200,16 +163,6 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esm@^3.2.5:
-  version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
 for-each@~0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -279,18 +232,6 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
-is-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
-  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
-
-is-reference@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.4.tgz#3f95849886ddb70256a3e6d062b1a68c13c51427"
-  integrity sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==
-  dependencies:
-    "@types/estree" "0.0.39"
-
 is-regex@^1.0.4, is-regex@^1.0.5, is-regex@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
@@ -309,13 +250,6 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-
-magic-string@^0.25.2:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
-  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
-  dependencies:
-    sourcemap-codec "^1.4.4"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -442,13 +376,6 @@ regexp.prototype.flags@^1.2.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-resolve@^1.11.0, resolve@^1.11.1:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.1.tgz#49fac5d8bacf1fd53f200fa51247ae736175832c"
-  integrity sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==
-  dependencies:
-    path-parse "^1.0.6"
-
 resolve@~1.15.1:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
@@ -463,44 +390,6 @@ resumer@~0.0.0:
   dependencies:
     through "~2.3.4"
 
-rollup-plugin-commonjs@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz#417af3b54503878e084d127adf4d1caf8beb86fb"
-  integrity sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
-  dependencies:
-    estree-walker "^0.6.1"
-    is-reference "^1.1.2"
-    magic-string "^0.25.2"
-    resolve "^1.11.0"
-    rollup-pluginutils "^2.8.1"
-
-rollup-plugin-node-resolve@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
-  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  dependencies:
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.11.1"
-    rollup-pluginutils "^2.8.1"
-
-rollup-pluginutils@^2.8.1:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
-
-rollup@^1.24.0:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
-
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -511,10 +400,15 @@ safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-sourcemap-codec@^1.4.4:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
-  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+ses@^0.14.3:
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.14.4.tgz#17d753d5fca460bfb362c2ed77e0bf7700f00e24"
+  integrity sha512-0ydKzChzQ/SgVn/rkzQ+sflYrxWRihtH2r7t5Vl92JFQbIJjJvp6vprs/1fwSsJppJg5drh8v6bTyaB6IizUCg==
+
+ses@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.15.0.tgz#35c585dc890bee9ea2e34a84a1fe6078c77604dd"
+  integrity sha512-8v354F7Ed4k3QVGIxgtmWrY7vafE6435bYm3BycTtyFRJT2Pln2G3w5/LzhaVhQB+EMFfKkvbCaA+hmMp6A7+Q==
 
 stream-shift@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,25 +25,6 @@
   resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.13.30.tgz#5addee2d18c165f477b89b7b4f44e48a4da29d17"
   integrity sha512-jwn4o161Jm/TWcPg0pE3UtJ2y1/0FEFmDVivDJIqI+K5freXXwr0OT2TOIctQGdsvNASPtRZLrdVUk9diYLbYQ==
 
-"@agoric/eventual-send@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.8.0.tgz#97d1c964fcb2f8adda3918b7ad7a2c8fb16c1764"
-  integrity sha512-lDxqz0O6odnhd6SDfYEZCyZu08yhf5SDVNAs3/HwCm+g3Ioob20o5zf8HIu0PrFH0MxpruISPxj7AfjphNaBZA==
-  dependencies:
-    "@agoric/harden" "^0.0.4"
-
-"@agoric/harden@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@agoric/harden/-/harden-0.0.4.tgz#b0d0b2fdfc1a8c7e60454374824442f5b37ea8bd"
-  integrity sha512-WvTw2otvchy3mScAvqQcX0l6049xp6cF17/Pw0PNNqUTJtOo/84tE9OyBSjEp8wn/XBNArPaJuRjMhQpIQ775Q==
-  dependencies:
-    "@agoric/make-hardener" "0.0.4"
-
-"@agoric/make-hardener@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.4.tgz#9b5d6692bc2fbbac2fff0a6682959ac5e69c582d"
-  integrity sha512-0k/wGkIVQO3IY7p/H/5OS3BIXsRK9Qb7nHnqyvj6hzvSyumwgPp8e4rz5QaVWSen43TGJl+zQn4mW9ZZShT1aw==
-
 "@agoric/marshal@^0.4.28":
   version "0.4.28"
   resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.4.28.tgz#cbbf9ebb41dcb382407af7a44d3f6eebc2d46726"


### PR DESCRIPTION
However, tests are failing:

ReferenceError: harden is not defined
    at file:///Users/danfinlay/Documents/captp-stream/node_modules/@agoric/marshal/src/helpers/passStyleHelpers.js:20:1

Opening as PR to highlight a problem I don't understand. I would have expected the `import 'ses'` statement would make harden available globally.